### PR TITLE
Inclusion to support Portuguese (Brazil/Europe) for the weekdays

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ Configuration for all views can be done using the ``CalendarConfig`` class.
    :header: "Parameter", "Type", "Description"
    :widths: 17, 10, 73
 
-   ``lang``, str, "Language, which is used for the name of the weekday. Supported values: en, ru, ua, es. Default value: **en**"
+   ``lang``, str, "Language, which is used for the name of the weekday. Supported values: en, ru, ua, es, pt. Default value: **en**"
    ``title``, str, "Title of the view. Can be empty"
    ``dates``, str, "The range of the days to show. Default value: **'Mo - Su'**"
    ``days``, int, "If ``dates`` does not exist, the number of days to display can be configured starting from Monday. For example, '4' means ``dates='Mo - Th'``"
@@ -91,7 +91,7 @@ Event
    :header: "Parameter", "Type", "Description"
    :widths: 20, 10, 70
 
-   ``name``, str, "Language, which is used for the name of the weekday. Supported values: en, ru, ua, es"
+   ``name``, str, "Language, which is used for the name of the weekday. Supported values: en, ru, ua, es, pt"
    ``day``, str / date / datetime, "The day of the event. Can be set using any of 3 different types. Can't be defined together with ``day_of_week``"
    ``day_of_week``, int, "The range of the days to show. Can't be defined together with ``day``"
    ``start``, str / time / datetime, "Start of the event. Can be set using any of 3 different types. The string has format **HH:mm** or **HH**."

--- a/calendar_view/config/i18n.py
+++ b/calendar_view/config/i18n.py
@@ -35,6 +35,15 @@ day_of_week_i18n = {
         'Sa',
         'Do'
     ],
+    'pt': [
+        'Se',
+        'Te',
+        'Qu',
+        'Qu',
+        'Se',
+        'Sa',
+        'Do'
+    ],
 }
 
 

--- a/calendar_view/core/time_utils.py
+++ b/calendar_view/core/time_utils.py
@@ -29,6 +29,13 @@ weekday_dict = {
     'vi': 4,
     'sa': 5,
     'do': 6,
+    'se': 0,
+    'te': 1,
+    'qu': 2,
+    'qu': 3,
+    'se': 4,
+    'sa': 5,
+    'do': 6,
 }
 time_regex = re.compile(r'^([0-9]{1,2})(:([0-9]{2}))?$')
 


### PR DESCRIPTION
Inclusion for another language: Portuguese, which covers both: European/Brazilian Portuguese for the weekdays